### PR TITLE
fix keyboard bug for "Create task list" button

### DIFF
--- a/src/components/inputs/Input.tsx
+++ b/src/components/inputs/Input.tsx
@@ -107,15 +107,9 @@ export const Input = (props: InputPropsType) => {
       ) : (
         <View style={styles.inputContainer}>
           <TextInput
-            autoFocus={!!inputRef}
             maxLength={maxLength}
             onBlur={onBlur}
             onChangeText={onChangeText}
-            onLayout={() => {
-              if (inputRef) {
-                inputRef.current?.focus();
-              }
-            }}
             placeholder={placeholder}
             placeholderTextColor={COLORS.SILVER_CHALICE2}
             ref={inputRef}


### PR DESCRIPTION
fix keyboard bug when user tap on "Create task list" button, focus(caret) be on input but keyboard didn't show (rollback commit 2745e892 "fix input random caret spawn on autofocus")